### PR TITLE
Fix test query name used by removing _

### DIFF
--- a/packages/cli/src/generator/templates/Component.test.tsx.ejs
+++ b/packages/cli/src/generator/templates/Component.test.tsx.ejs
@@ -17,7 +17,7 @@ describe("<%= componentName %>", () => {
       Component: <%= componentName %>,
       query: graphql`
         # TODO: Add parameters or nest the fragment spread inside a root field, as necessary.
-        query <%= componentName %>_Test_Query {
+        query <%= componentName %>TestQuery {
           ...<%= relayTypeName %>
         }
       `,


### PR DESCRIPTION
# Problem
`yarn relay` fails on default query name used in the tests. It doesn't like `_` in the name and expects it to be `<component name>TestQuery`

# Solution
Remove `_`